### PR TITLE
fix in emacsrunregion regarding call to regexp

### DIFF
--- a/toolbox/emacsrunregion.m
+++ b/toolbox/emacsrunregion.m
@@ -44,8 +44,7 @@ function emacsrunregion(file, startchar, endchar)
 
     % See if startchar and endchar are on the first column of a lines and if so display that. Note,
     % fileContents can contain POSIX newlines (LF) or be Windows CRFL (13, 10) line endings.
-    if (startchar == 1 || fileContents(startchar-1) == newline) && ...
-            regexp(fileContents(endchar), '[\r\n]', 'once')
+    if (startchar == 1 || fileContents(startchar-1) == newline) && ~isempty(regexp(fileContents(endchar), '[\r\n]', 'once'))
         startLineNum = length(strfind(fileContents(1:startchar), newline)) + 1;
         endLineNum = length(strfind(fileContents(1:endchar), newline));
         if fileContents(endchar) == 13 || endchar == length(fileContents)


### PR DESCRIPTION
regexp function does not return a boolean. In particular, it returns empty if not found, see https://se.mathworks.com/help/matlab/ref/regexp.html